### PR TITLE
Enable N domains

### DIFF
--- a/dev/cmb/simulation-workflows/ats/ats.py
+++ b/dev/cmb/simulation-workflows/ats/ats.py
@@ -16,6 +16,7 @@ Export operator for ATS workflows
 import imp
 import os
 import sys
+import traceback
 
 import smtk
 import smtk.attribute
@@ -46,8 +47,11 @@ class Export(smtk.operation.Operation):
     def operateInternal(self):
         try:
             success = ExportCMB(self)
-        except:
-            print('Error', self.log().convertToString())
+        except Exception as e:
+            print("\n\nERROR:")
+            track = traceback.format_exc()
+            print(track)
+            print("\n\n")
             #smtk.ErrorMessage(self.log(), sys.exc_info()[0])
             raise
             return self.createResult(smtk.operation.Operation.Outcome.FAILED)

--- a/dev/cmb/simulation-workflows/ats/ats.py
+++ b/dev/cmb/simulation-workflows/ats/ats.py
@@ -87,6 +87,13 @@ def ExportCMB(export_op):
     params = export_op.parameters()
     logger = export_op.log()
 
+    # Get the simulation attribute resource
+    sim_atts = smtk.attribute.Resource.CastTo(params.find('attributes').value())
+    if sim_atts is None:
+        msg = 'ERROR - No simulation attributes'
+        print(msg)
+        raise RuntimeError(msg)
+
     # Get output filepath
     output_file_item = params.findFile('output-file')
     output_file = output_file_item.value(0)
@@ -99,7 +106,7 @@ def ExportCMB(export_op):
     from internal.writer import ats_writer
     imp.reload(ats_writer)
 
-    writer = ats_writer.ATSWriter(params)
+    writer = ats_writer.ATSWriter(sim_atts)
     completed = writer.write(output_file)
     print('Writer completion status: %s' % completed)
 
@@ -107,8 +114,8 @@ def ExportCMB(export_op):
     if sys.stdout is not None:
         sys.stdout.flush()
 
-    print('ats.py number of warnings:', len(writer.warning_messages))
-    for msg in writer.warning_messages:
-        logger.addWarning(msg)
+    # print('ats.py number of warnings:', len(writer.warning_messages))
+    # for msg in writer.warning_messages:
+    #     logger.addWarning(msg)
 
     return completed

--- a/dev/cmb/simulation-workflows/ats/ats.sbt
+++ b/dev/cmb/simulation-workflows/ats/ats.sbt
@@ -4,6 +4,7 @@
   <Includes>
     <!-- Mesh and Regions -->
     <File>internal/templates/domain.sbt</File>
+    <File>internal/templates/region.sbt</File>
     <!-- cycle driver -->
     <File>internal/templates/coordinator.sbt</File>
     <!-- PKs -->
@@ -16,7 +17,8 @@
   <Views>
     <View Type="Group" Title="ATS" TopLevel="true" TabPosition="North" FilterByAdvanceLevel="true" FilterByCategory="false">
       <Views>
-        <View Title="Domain"/>
+        <View Title="Domains"/>
+        <View Title="Regions"/>
         <View Title="Coordinator"/>
         <View Title="Process Kernel"/>
         <View Title="Visualization"/>
@@ -25,16 +27,10 @@
         <View Title="State"/>
       </Views>
     </View>
-    <View Type="Group" Title="Domain" Style="Tiled">
-      <Views>
-        <View Title="Mesh"/>
-        <View Title="Regions"/>
-      </Views>
-    </View>
-    <View Type="Instanced" Title="Mesh">
-      <InstancedAttributes>
-        <Att Type="mesh" Name="mesh"/>
-      </InstancedAttributes>
+    <View Type="Attribute" Title="Domains">
+      <AttributeTypes>
+        <Att Type="domain"/>
+      </AttributeTypes>
     </View>
     <View Type="Attribute" Title="Regions">
       <AttributeTypes>

--- a/dev/cmb/simulation-workflows/ats/ats.sbt
+++ b/dev/cmb/simulation-workflows/ats/ats.sbt
@@ -47,10 +47,10 @@
         <Att Type="pk-base"/>
       </AttributeTypes>
     </View>
-    <View Type="Instanced" Title="Visualization">
-      <InstancedAttributes>
-        <Att Type="visualization driver" Name="visualization driver"/>
-      </InstancedAttributes>
+    <View Type="Attribute" Title="Visualization">
+      <AttributeTypes>
+        <Att Type="visualization driver"/>
+      </AttributeTypes>
     </View>
     <View Type="Instanced" Title="Checkpoint">
       <InstancedAttributes>

--- a/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
@@ -49,7 +49,7 @@
             <Void Name="flyweight mesh" Label="flyweight mesh" Optional="true" IsEnabledByDefault="false">
               <BriefDescription>NOT YET SUPPORTED. Allows a single mesh instead of one per entity.</BriefDescription>
             </Void>
-            <String Name="export mesh to file" Optional="true" IsEnabledByDefault="false"></String>
+            <File Name="export mesh to file" ShouldExist="false" Optional="true" IsEnabledByDefault="false"></File>
           </ChildrenDefinitions>
           <!-- Here is where we list the options - they can adopt children from above -->
           <DiscreteInfo DefaultIndex="0">

--- a/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
@@ -49,6 +49,7 @@
             <Void Name="flyweight mesh" Label="flyweight mesh" Optional="true" IsEnabledByDefault="false">
               <BriefDescription>NOT YET SUPPORTED. Allows a single mesh instead of one per entity.</BriefDescription>
             </Void>
+            <File Name="export mesh to file" ShouldExist="false" Optional="true" IsEnabledByDefault="false"></File>
           </ChildrenDefinitions>
           <!-- Here is where we list the options - they can adopt children from above -->
           <DiscreteInfo DefaultIndex="0">
@@ -76,6 +77,7 @@
                 <!-- TODO: this can be `surface sideset name` or `surface sideset names`-->
                 <!-- TODO: How do we deal with option to have one or many? -->
                 <Item>surface sideset name</Item>
+                <Item>export mesh to file</Item>
               </Items>
             </Structure>
             <!-- "subgrid mesh" -->

--- a/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
@@ -49,7 +49,7 @@
             <Void Name="flyweight mesh" Label="flyweight mesh" Optional="true" IsEnabledByDefault="false">
               <BriefDescription>NOT YET SUPPORTED. Allows a single mesh instead of one per entity.</BriefDescription>
             </Void>
-            <File Name="export mesh to file" ShouldExist="false" Optional="true" IsEnabledByDefault="false"></File>
+            <String Name="export mesh to file" Optional="true" IsEnabledByDefault="false"></String>
           </ChildrenDefinitions>
           <!-- Here is where we list the options - they can adopt children from above -->
           <DiscreteInfo DefaultIndex="0">

--- a/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
@@ -3,7 +3,7 @@
   <Definitions>
 
     <!-- ATS mesh types -->
-    <AttDef Type="mesh" Label="Mesh" BaseType="" Version="0">
+    <AttDef Type="domain" Label="Domains" BaseType="" Version="0">
       <ItemDefinitions>
         <!-- Where the mesh type is chosen: only one per simulation -->
         <String Name="mesh type">
@@ -110,70 +110,5 @@
       </ItemDefinitions>
     </AttDef>
 
-
-    <!-- Region subdomains -->
-    <!-- TODO: can we ensure that a user never repeats a region name? -->
-    <AttDef Type="region" Label="Region" Abstract="true" Version="0"></AttDef>
-    <AttDef Type="region: all" BaseType="region"></AttDef>
-    <AttDef Type="region: box" BaseType="region">
-      <ItemDefinitions>
-        <Double Name="low coordinate" NumberOfRequiredValues="3"></Double>
-        <Double Name="high coordinate" NumberOfRequiredValues="3"></Double>
-      </ItemDefinitions>
-    </AttDef>
-    <AttDef Type="region: plane" BaseType="region">
-      <ItemDefinitions>
-        <Double Name="point" NumberOfRequiredValues="3"></Double>
-        <Double Name="normal" NumberOfRequiredValues="3"></Double>
-      </ItemDefinitions>
-    </AttDef>
-    <AttDef Type="region: labeled set" BaseType="region">
-      <ItemDefinitions>
-        <String Name="label"></String>
-        <!-- TODO: the spec says that this is the same mesh file as the section above. How do we link the two? Is this okay? -->
-        <Component Name="file">
-          <Accepts>
-            <Resource Name="smtk::attribute::Resource" Filter="attribute[type='file']"></Resource>
-          </Accepts>
-        </Component>
-        <!-- TODO: same as above but for the mesh format! -->
-        <String Name="entity">
-          <DiscreteInfo  DefaultIndex="0">
-            <Value Enum="cell">cell</Value>
-            <Value Enum="face">face</Value>
-            <Value Enum="node">node</Value>
-          </DiscreteInfo>
-        </String>
-      </ItemDefinitions>
-    </AttDef>
-    <AttDef Type="region: color function" BaseType="region">
-      <ItemDefinitions>
-        <File Name="file" ShouldExist="true"></File>
-        <Int Name="value"></Int>
-      </ItemDefinitions>
-    </AttDef>
-    <AttDef Type="region: point" BaseType="region">
-      <ItemDefinitions>
-        <Double Name="point" NumberOfRequiredValues="3"></Double>
-      </ItemDefinitions>
-    </AttDef>
-    <AttDef Type="region: logical" BaseType="region">
-      <ItemDefinitions>
-        <String Name="operation">
-          <DiscreteInfo DefaultIndex="0">
-            <Value Enum="union">union</Value>
-            <Value Enum="intersect">intersect</Value>
-            <Value Enum="subtract">subtract</Value>
-            <Value Enum="complement">complement</Value>
-          </DiscreteInfo>
-        </String>
-        <!-- TODO: insert a list of Strings -->
-      </ItemDefinitions>
-    </AttDef>
-    <!-- TODO: Polygon -->
-    <!-- TODO: Enumerated -->
-    <!-- TODO: Boundary -->
-    <!-- TODO: Box Volume Fractions -->
-    <!-- TODO: Line Segment -->
   </Definitions>
 </SMTK_AttributeResource>

--- a/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/domain.sbt
@@ -102,7 +102,7 @@
           <BriefDescription>Will this mesh be deformed?</BriefDescription>
         </Void>
         <!-- “partitioner” [string] (zoltan_rcb) Method to partition the mesh. -->
-        <String Name="partitioner">
+        <String Name="partitioner" Optional="true">
           <DiscreteInfo DefaultIndex="0">
             <Value Enum="zoltan_rcb/map view">zoltan_rcb</Value>
             <Value Enum="METIS">metis</Value>

--- a/dev/cmb/simulation-workflows/ats/internal/templates/region.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/region.sbt
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SMTK_AttributeResource Version="3">
+  <Definitions>
+
+    <!-- Region subdomains -->
+    <!-- TODO: can we ensure that a user never repeats a region name? -->
+    <AttDef Type="region" Label="Region" Abstract="true" Version="0"></AttDef>
+    <AttDef Type="region: all" BaseType="region"></AttDef>
+    <AttDef Type="region: box" BaseType="region">
+      <ItemDefinitions>
+        <Double Name="low coordinate" NumberOfRequiredValues="3"></Double>
+        <Double Name="high coordinate" NumberOfRequiredValues="3"></Double>
+      </ItemDefinitions>
+    </AttDef>
+    <AttDef Type="region: plane" BaseType="region">
+      <ItemDefinitions>
+        <Double Name="point" NumberOfRequiredValues="3"></Double>
+        <Double Name="normal" NumberOfRequiredValues="3"></Double>
+      </ItemDefinitions>
+    </AttDef>
+    <AttDef Type="region: labeled set" BaseType="region">
+      <ItemDefinitions>
+        <String Name="label"></String>
+        <!-- TODO: the spec says that this is the same mesh file as the section above. How do we link the two? Is this okay? -->
+        <Component Name="file">
+          <Accepts>
+            <Resource Name="smtk::attribute::Resource" Filter="attribute[type='file']"></Resource>
+          </Accepts>
+        </Component>
+        <!-- TODO: same as above but for the mesh format! -->
+        <String Name="entity">
+          <DiscreteInfo  DefaultIndex="0">
+            <Value Enum="cell">cell</Value>
+            <Value Enum="face">face</Value>
+            <Value Enum="node">node</Value>
+          </DiscreteInfo>
+        </String>
+      </ItemDefinitions>
+    </AttDef>
+    <AttDef Type="region: color function" BaseType="region">
+      <ItemDefinitions>
+        <File Name="file" ShouldExist="true"></File>
+        <Int Name="value"></Int>
+      </ItemDefinitions>
+    </AttDef>
+    <AttDef Type="region: point" BaseType="region">
+      <ItemDefinitions>
+        <Double Name="point" NumberOfRequiredValues="3"></Double>
+      </ItemDefinitions>
+    </AttDef>
+    <AttDef Type="region: logical" BaseType="region">
+      <ItemDefinitions>
+        <String Name="operation">
+          <DiscreteInfo DefaultIndex="0">
+            <Value Enum="union">union</Value>
+            <Value Enum="intersect">intersect</Value>
+            <Value Enum="subtract">subtract</Value>
+            <Value Enum="complement">complement</Value>
+          </DiscreteInfo>
+        </String>
+        <!-- TODO: insert a list of Strings -->
+      </ItemDefinitions>
+    </AttDef>
+    <!-- TODO: Polygon -->
+    <!-- TODO: Enumerated -->
+    <!-- TODO: Boundary -->
+    <!-- TODO: Box Volume Fractions -->
+    <!-- TODO: Line Segment -->
+  </Definitions>
+</SMTK_AttributeResource>

--- a/dev/cmb/simulation-workflows/ats/internal/templates/source/visualization.sbs
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/source/visualization.sbs
@@ -3,6 +3,12 @@
   <Definitions>
     <AttDef Type="visualization driver" BaseType="" Version="0">
       <ItemDefinitions>
+        <Component Name="domain">
+          <Accepts>
+            <Resource Name="smtk::attribute::Resource" Filter="attribute[type='domain']"></Resource>
+          </Accepts>
+        </Component>
+
         <File Name="file name base" ShouldExist="false">
           <!-- TODO: file name "visdump_DOMAIN_data" -->
           <!-- CAN we dynamically set this based on the domain? -->

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -96,6 +96,7 @@ class ATSWriter:
 
     def _render_items(self, parent_elem, att, param_names):
         """Generates Parameter elements for items specified by param_names"""
+        assert isinstance(param_names, list)
         for param_name in param_names:
             item = att.find(param_name)
             if item is None:

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -115,6 +115,7 @@ class ATSWriter:
                 value = item.value()
 
             self._new_param(parent_elem, param_name, type_string, value)
+        return
 
     #### This section contains methods to write each Main element ####
 
@@ -128,6 +129,7 @@ class ATSWriter:
             # TODO: column mesh
         }
         # TODO: some of the demo files do not have these - when should we include them and when not?
+        #       other sim files have them under an `expert` param list??
         main_param_names = ['verify mesh', 'deformable mesh', 'partitioner']
         ####
         # Logic to render the mesh section
@@ -136,7 +138,7 @@ class ATSWriter:
         domain_elem = self._new_list(mesh_elem, 'domain')
 
         type_item = mesh_att.findString('mesh type')
-        type_elem = self._new_param(domain_elem, type_item.name(), 'string', type_item.value())
+        _ = self._new_param(domain_elem, type_item.name(), 'string', type_item.value())
 
         #  Winging it here to generate the parameters list
         gen_params_list_name = '{} parameters'.format(type_item.value())

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -119,9 +119,21 @@ class ATSWriter:
     #### This section contains methods to write each Main element ####
 
     def _generate_mesh_xml(self):
+        # possible children parameters
+        children = {
+            'generate mesh': ['domain low coordinate', 'domain high coordinate', 'number of cells'],
+            'read mesh file': ['file', 'format'],
+            'surface': ['urface sideset name', ], # TODO: more
+            'subgrid': ['subgrid region name', 'entity kind', 'parent domain', 'flyweight mesh'],
+            # TODO: column mesh
+        }
+        # TODO: some of the demo files do not have these - when should we include them and when not?
+        main_param_names = ['verify mesh', 'deformable mesh', 'partitioner']
+        ####
+        # Logic to render the mesh section
         mesh_elem = self._new_list(self.xml_root, 'mesh')
         mesh_att = self.sim_atts.findAttribute('mesh')
-        domain_elem = self._new_list(mesh_elem, mesh_att.name())
+        domain_elem = self._new_list(mesh_elem, 'domain')
 
         type_item = mesh_att.findString('mesh type')
         type_elem = self._new_param(domain_elem, type_item.name(), 'string', type_item.value())
@@ -129,12 +141,11 @@ class ATSWriter:
         #  Winging it here to generate the parameters list
         gen_params_list_name = '{} parameters'.format(type_item.value())
         gen_params_list = self._new_list(domain_elem, gen_params_list_name)
-        gen_param_names = ['number of cells', 'domain low coordinate', 'domain high coordinate']
-        self._render_items(gen_params_list, mesh_att, gen_param_names)
+        known_children = children.get(type_item.value(), [])
+        self._render_items(gen_params_list, type_item, known_children)
 
-        # TODO: some of the demo files do not have these - when should we include them and when not?
-        param_names = ['verify mesh', 'deformable mesh', 'partitioner']
-        self._render_items(domain_elem, mesh_att, param_names)
+        # Top level mesh parameters
+        self._render_items(domain_elem, mesh_att, main_param_names)
         return
 
     def _generate_regions_xml(self):

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -134,9 +134,8 @@ class ATSWriter:
             'subgrid': ['subgrid region name', 'entity kind', 'parent domain', 'flyweight mesh'],
             # TODO: column mesh
         }
-        # TODO: some of the demo files do not have these - when should we include them and when not?
-        #       other sim files have them under an `expert` param list??
-        main_param_names = ['verify mesh', 'deformable mesh', 'partitioner']
+        main_param_names = ['verify mesh', 'deformable mesh']
+        # Note about `'partitioner'`: it only makes sense on the "domain" mesh
         ####
         # Logic to render the mesh section
         mesh_elem = self._new_list(self.xml_root, 'mesh')
@@ -152,6 +151,10 @@ class ATSWriter:
             gen_params_list = self._new_list(domain_elem, gen_params_list_name)
             known_children = children.get(mesh_type, [])
             self._render_items(gen_params_list, type_item, known_children)
+            # TODO: If a `domain` mesh, not a surface or otherwise, add the partitioner option:
+            #       there aren't any examples of this being used, so leaving out
+            # if domain mesh: # psuedo-code
+            #     self._render_items(gen_params_list, type_item, ['partitioner',])
             # Top level mesh parameters
             self._render_items(domain_elem, domain_att, main_param_names)
         return

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -101,6 +101,11 @@ class ATSWriter:
             if item is None:
                 continue
 
+            # if (optional and enabled and not a bool) else continue
+            # this allows us to skip optional parameters
+            if (hasattr(item, "isOptional") and item.type() != smtk.attribute.Item.VoidType) and not item.isEnabled():
+                continue
+
             type_string = TypeStringMap.get(item.type())
             value = None
             if item.type() == smtk.attribute.Item.VoidType:
@@ -125,7 +130,6 @@ class ATSWriter:
         children = {
             'generate mesh': ['domain low coordinate', 'domain high coordinate', 'number of cells'],
             'read mesh file': ['file', 'format'],
-            # TODO: `export mesh to file` is optional - don't include unless valid
             'surface': ['urface sideset name', 'export mesh to file', ], # TODO: more
             'subgrid': ['subgrid region name', 'entity kind', 'parent domain', 'flyweight mesh'],
             # TODO: column mesh

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -53,28 +53,20 @@ class ATSWriter:
         self.xml_root.setAttribute('type', 'ParameterList')
         self.xml_doc.appendChild(self.xml_root)
 
-        # Render mesh element
-        mesh_elem = self._new_list(self.xml_root, 'mesh')
-        mesh_att = self.sim_atts.findAttribute('mesh')
-        domain_elem = self._new_list(mesh_elem, mesh_att.name())
-        type_item = mesh_att.findString('mesh type')
-        type_elem = self._new_param(domain_elem, type_item.name(), 'string', type_item.value())
-        #  Winging it here to generate the parameters list
-        gen_params_list_name = '{} parameters'.format(type_item.value())
-        gen_params_list = self._new_list(domain_elem, gen_params_list_name)
-        gen_param_names = ['number of cells', 'domain low coordinate', 'domain high coordinate']
-        self._render_items(gen_params_list, mesh_att, gen_param_names)
 
-        param_names = ['verify mesh', 'deformable mesh', 'partitioner']
-        self._render_items(domain_elem, mesh_att, param_names)
+        ################################
 
-        # Render region elements
-        regions_elem = self._new_list(self.xml_root, 'regions')
-        region_atts = self.sim_atts.findAttributes('region')
-        for region_att in region_atts:
-            list_elem = self._new_list(regions_elem, region_att.name())
-            type_list = self._new_list(list_elem, region_att.type())
-            self._render_items(type_list, region_att, ['point', 'normal'])
+        self._generate_mesh_xml()
+        self._generate_regions_xml()
+        ## TODO: uncomment as implemented
+        # self._generate_cycle_driver_xml()
+        # self._generate_visualization_xml()
+        # self._generate_observations_xml()
+        # self._generate_checkpoint_xml()
+        # self._generate_pks_xml()
+        # self._generate_state_xml()
+
+        ################################
 
         # Write output file
         wrote_file = False
@@ -123,3 +115,65 @@ class ATSWriter:
                 value = item.value()
 
             self._new_param(parent_elem, param_name, type_string, value)
+
+    #### This section contains methods to write each Main element ####
+
+    def _generate_mesh_xml(self):
+        mesh_elem = self._new_list(self.xml_root, 'mesh')
+        mesh_att = self.sim_atts.findAttribute('mesh')
+        domain_elem = self._new_list(mesh_elem, mesh_att.name())
+
+        type_item = mesh_att.findString('mesh type')
+        type_elem = self._new_param(domain_elem, type_item.name(), 'string', type_item.value())
+
+        #  Winging it here to generate the parameters list
+        gen_params_list_name = '{} parameters'.format(type_item.value())
+        gen_params_list = self._new_list(domain_elem, gen_params_list_name)
+        gen_param_names = ['number of cells', 'domain low coordinate', 'domain high coordinate']
+        self._render_items(gen_params_list, mesh_att, gen_param_names)
+
+        # TODO: some of the demo files do not have these - when should we include them and when not?
+        param_names = ['verify mesh', 'deformable mesh', 'partitioner']
+        self._render_items(domain_elem, mesh_att, param_names)
+        return
+
+    def _generate_regions_xml(self):
+        # possible children parameters
+        children = {
+            'region: plane': ['point', 'normal',],
+            'region: box': ['low coordinate', 'high coordinate',],
+            'region: labeled set': ['label', 'file', 'entity',],
+            'region: color function': ['file', 'value',],
+            'region: point': ['point',],
+            'region: logical': ['operation',],
+            # TODO: there's more to fill in here!
+        }
+        ####
+        # Logic to render it - shouldn't need any changes
+        regions_elem = self._new_list(self.xml_root, 'regions')
+        region_atts = self.sim_atts.findAttributes('region')
+        for region_att in region_atts:
+            list_elem = self._new_list(regions_elem, region_att.name())
+            type_list = self._new_list(list_elem, region_att.type())
+            # Get list of known children for given attribute
+            known_children = children.get(region_att.type(), [])
+            self._render_items(type_list, region_att, known_children)
+        return
+
+    def _generate_cycle_driver_xml(self):
+        raise NotImplementedError()
+
+    def _generate_visualization_xml(self):
+        raise NotImplementedError()
+
+    def _generate_observations_xml(self):
+        raise NotImplementedError()
+
+    def _generate_checkpoint_xml(self):
+        raise NotImplementedError()
+
+    def _generate_pks_xml(self):
+        raise NotImplementedError()
+
+    def _generate_state_xml(self):
+        raise NotImplementedError()

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -102,6 +102,8 @@ class ATSWriter:
             if item is None:
                 continue
 
+            # TODO: we need to handle `ComponentType`
+
             # skip over optional items if not enabled. Bools are never optional... weird logic here.
             if item.type() != smtk.attribute.Item.VoidType and not item.isEnabled():
                 continue
@@ -119,6 +121,10 @@ class ATSWriter:
                 value = r"{" + ', '.join(string_list) + r"}"
             elif hasattr(item, 'value'):
                 value = item.value()
+
+            ####
+            if value is None or not isinstance(value, str):
+                raise NotImplementedError("({}) for ({}) is not handled".format(item.type(), param_name))
 
             self._new_param(parent_elem, param_name, type_string, value)
         return

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -21,7 +21,8 @@ TypeStringMap = {
     smtk.attribute.Item.DoubleType: 'double',
     smtk.attribute.Item.IntType: 'int',
     smtk.attribute.Item.StringType: 'string',
-    smtk.attribute.Item.VoidType: 'bool'
+    smtk.attribute.Item.VoidType: 'bool',
+    smtk.attribute.Item.FileType: 'string',
 }
 
 

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -102,9 +102,8 @@ class ATSWriter:
             if item is None:
                 continue
 
-            # if (optional and enabled and not a bool) else continue
-            # this allows us to skip optional parameters
-            if (hasattr(item, "isOptional") and item.type() != smtk.attribute.Item.VoidType) and not item.isEnabled():
+            # skip over optional items if not enabled. Bools are never optional... weird logic here.
+            if item.type() != smtk.attribute.Item.VoidType and not item.isEnabled():
                 continue
 
             type_string = TypeStringMap.get(item.type())

--- a/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/ats_writer.py
@@ -10,6 +10,7 @@
 #
 # =============================================================================
 
+import imp
 import os
 print('loading', os.path.basename(__file__))
 from xml.dom import minidom
@@ -17,47 +18,44 @@ from xml.dom import minidom
 import smtk
 import smtk.attribute
 
-TypeStringMap = {
-    smtk.attribute.Item.DoubleType: 'double',
-    smtk.attribute.Item.IntType: 'int',
-    smtk.attribute.Item.StringType: 'string',
-    smtk.attribute.Item.VoidType: 'bool',
-    smtk.attribute.Item.FileType: 'string',
-}
+from .shared_data import instance as shared
+
+from . import base_writer
+imp.reload(base_writer)
+from .base_writer import BaseWriter
 
 
-class ATSWriter:
-    """Top level writer class for ATS input files."""
+class ATSWriter(BaseWriter):
+    """Top level writer for ATS input files."""
 
-    def __init__(self, export_params):
+    def __init__(self, sim_atts):
         """Initializes the exporter class with the simulation parameters.
-        """
-        self.checked_attributes = set()  # attributes that have been validated
-        self.model_resource = None
-        self.sim_atts = None
-        self.warning_messages = list()
-        self.xml_doc = None
-        self.xml_root = None
 
-        self.sim_atts = smtk.attribute.Resource.CastTo(export_params.find('attributes').value())
-        # print('sim_atts', self.sim_atts)
-        if self.sim_atts is None:
-            msg = 'ERROR - No simulation attributes'
-            print(msg)
-            raise RuntimeError(msg)
+        Inputs:
+          sim_atts: attribute resource specifying simulation
+        """
+        super(ATSWriter, self).__init__()
+        self.sim_atts = sim_atts
+        self.xml_root = None
 
     def write(self, output_filepath):
         """Generate the xml output file."""
-        self.xml_doc = minidom.Document()
-        self.xml_root = self.xml_doc.createElement('ParameterList')
+        shared.initialize(self.sim_atts, minidom.Document())
+
+        self.xml_root = shared.xml_doc.createElement('ParameterList')
         self.xml_root.setAttribute('name', 'Main')
         self.xml_root.setAttribute('type', 'ParameterList')
-        self.xml_doc.appendChild(self.xml_root)
+        shared.xml_doc.appendChild(self.xml_root)
 
 
         ################################
 
-        self._generate_domains_xml()
+        # self._generate_domains_xml()
+        from . import domain_writer
+        imp.reload(domain_writer)
+        domain_writer.DomainWriter().write(self.xml_root)
+
+
         self._generate_regions_xml()
         ## TODO: uncomment as implemented
         # self._generate_cycle_driver_xml()
@@ -72,98 +70,12 @@ class ATSWriter:
         # Write output file
         wrote_file = False
         with open(output_filepath, 'w') as fp:
-            xml_string = self.xml_doc.toprettyxml(indent=" ")
+            xml_string = shared.xml_doc.toprettyxml(indent=" ")
             fp.write(xml_string)
             wrote_file = True
         return wrote_file
 
-    def _new_list(self, parent, list_name, list_type='ParameterList'):
-        """Appends ParameterList element to parent"""
-        new_list = self.xml_doc.createElement('ParameterList')
-        new_list.setAttribute('name', list_name)
-        new_list.setAttribute('type', list_type)
-        parent.appendChild(new_list)
-        return new_list
-
-    def _new_param(self, list_elem, param_name, param_type, param_value):
-        """Appends Parameter element to list_elem"""
-        new_param = self.xml_doc.createElement('Parameter')
-        new_param.setAttribute('name', param_name)
-        new_param.setAttribute('type', param_type)
-        new_param.setAttribute('value', param_value)
-        list_elem.appendChild(new_param)
-        return new_param
-
-    def _render_items(self, parent_elem, att, param_names):
-        """Generates Parameter elements for items specified by param_names"""
-        assert isinstance(param_names, list)
-        for param_name in param_names:
-            item = att.find(param_name)
-            if item is None:
-                continue
-
-            # TODO: we need to handle `ComponentType`
-
-            # skip over optional items if not enabled. Bools are never optional... weird logic here.
-            if item.type() != smtk.attribute.Item.VoidType and not item.isEnabled():
-                continue
-
-            type_string = TypeStringMap.get(item.type())
-            value = None
-            if item.type() == smtk.attribute.Item.VoidType:
-                value = 'true' if item.isEnabled() else 'false'
-            elif hasattr(item, 'numberOfValues') and item.numberOfValues() > 1:
-                type_string = 'Array({})'.format(type_string)
-                value_list = list()
-                for i in range(item.numberOfValues()):
-                    value_list.append(item.value(i))
-                string_list = [str(x) for x in value_list]
-                value = r"{" + ', '.join(string_list) + r"}"
-            elif hasattr(item, 'value'):
-                value = item.value()
-
-            ####
-            if value is None or not isinstance(value, str):
-                raise NotImplementedError("({}) for ({}) is not handled".format(item.type(), param_name))
-
-            self._new_param(parent_elem, param_name, type_string, value)
-        return
-
     #### This section contains methods to write each Main element ####
-
-    def _generate_domains_xml(self):
-        # possible children parameters
-        children = {
-            'generate mesh': ['domain low coordinate', 'domain high coordinate', 'number of cells'],
-            'read mesh file': ['file', 'format'],
-            'surface': ['urface sideset name', 'export mesh to file', ], # TODO: more
-            'subgrid': ['subgrid region name', 'entity kind', 'parent domain', 'flyweight mesh'],
-            # TODO: column mesh
-        }
-        main_param_names = ['verify mesh', 'deformable mesh']
-        # Note about `'partitioner'`: it only makes sense on the "domain" mesh
-        ####
-        # Logic to render the mesh section
-        mesh_elem = self._new_list(self.xml_root, 'mesh')
-        domain_atts = self.sim_atts.findAttributes('domain')
-        for domain_att in domain_atts:
-            # save out each domain
-            domain_elem = self._new_list(mesh_elem, domain_att.name())
-            type_item = domain_att.findString('mesh type')
-            mesh_type = type_item.value()
-            _ = self._new_param(domain_elem, 'mesh type', 'string', mesh_type)
-            #  Winging it here to generate the parameters list
-            gen_params_list_name = '{} parameters'.format(mesh_type)
-            gen_params_list = self._new_list(domain_elem, gen_params_list_name)
-            known_children = children.get(mesh_type, [])
-            self._render_items(gen_params_list, type_item, known_children)
-            # TODO: If a `domain` mesh, not a surface or otherwise, add the partitioner option:
-            #       there aren't any examples of this being used, so leaving out
-            # if domain mesh: # psuedo-code
-            #     self._render_items(gen_params_list, type_item, ['partitioner',])
-            # Top level mesh parameters
-            self._render_items(domain_elem, domain_att, main_param_names)
-        return
 
     def _generate_regions_xml(self):
         # possible children parameters
@@ -179,7 +91,7 @@ class ATSWriter:
         ####
         # Logic to render it - shouldn't need any changes
         regions_elem = self._new_list(self.xml_root, 'regions')
-        region_atts = self.sim_atts.findAttributes('region')
+        region_atts = shared.sim_atts.findAttributes('region')
         for region_att in region_atts:
             list_elem = self._new_list(regions_elem, region_att.name())
             type_list = self._new_list(list_elem, region_att.type())

--- a/dev/cmb/simulation-workflows/ats/internal/writer/base_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/base_writer.py
@@ -1,0 +1,96 @@
+# =============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+# =============================================================================
+
+"""Common base class for writers"""
+
+import os
+print('loading', os.path.basename(__file__))
+from xml.dom import minidom
+
+import smtk
+import smtk.attribute
+
+from .shared_data import instance as shared
+
+TypeStringMap = {
+    smtk.attribute.Item.DoubleType: 'double',
+    smtk.attribute.Item.IntType: 'int',
+    smtk.attribute.Item.StringType: 'string',
+    smtk.attribute.Item.VoidType: 'bool',
+    smtk.attribute.Item.FileType: 'string',
+}
+
+
+class BaseWriter:
+    """Base writer class for ATS input files.
+
+    Should ONLY contain methods (no member data)
+    """
+
+    def __init__(self):
+        """"""
+        # Do NOT include any member data
+        pass
+
+    def _new_list(self, parent, list_name, list_type='ParameterList'):
+        """Appends ParameterList element to parent"""
+        new_list = shared.xml_doc.createElement('ParameterList')
+        new_list.setAttribute('name', list_name)
+        new_list.setAttribute('type', list_type)
+        parent.appendChild(new_list)
+        return new_list
+
+    def _new_param(self, list_elem, param_name, param_type, param_value):
+        """Appends Parameter element to list_elem"""
+        new_param = shared.xml_doc.createElement('Parameter')
+        new_param.setAttribute('name', param_name)
+        new_param.setAttribute('type', param_type)
+        new_param.setAttribute('value', param_value)
+        list_elem.appendChild(new_param)
+        return new_param
+
+    def _render_items(self, parent_elem, att, param_names):
+        """Generates Parameter elements for items specified by param_names"""
+        assert isinstance(param_names, list)
+        for param_name in param_names:
+            item = att.find(param_name)
+            if item is None:
+                continue
+
+            # TODO: we need to handle `ComponentType`
+
+            # skip over optional items if not enabled. Bools are never optional... weird logic here.
+            if item.type() != smtk.attribute.Item.VoidType and not item.isEnabled():
+                continue
+
+            type_string = TypeStringMap.get(item.type())
+            value = None
+            if item.type() == smtk.attribute.Item.VoidType:
+                value = 'true' if item.isEnabled() else 'false'
+            elif hasattr(item, 'numberOfValues') and item.numberOfValues() > 1:
+                type_string = 'Array({})'.format(type_string)
+                value_list = list()
+                for i in range(item.numberOfValues()):
+                    value_list.append(item.value(i))
+                string_list = [str(x) for x in value_list]
+                value = r"{" + ', '.join(string_list) + r"}"
+            elif hasattr(item, 'value'):
+                value = item.value()
+
+            ####
+            if value is None or not isinstance(value, str):
+                raise NotImplementedError("({}) for ({}) is not handled".format(item.type(), param_name))
+
+            self._new_param(parent_elem, param_name, type_string, value)
+        return
+
+

--- a/dev/cmb/simulation-workflows/ats/internal/writer/domain_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/domain_writer.py
@@ -1,0 +1,63 @@
+# =============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+# =============================================================================
+
+import imp
+import os
+print('loading', os.path.basename(__file__))
+from xml.dom import minidom
+
+import smtk
+import smtk.attribute
+
+from .shared_data import instance as shared
+from . import base_writer
+from .base_writer import BaseWriter
+
+
+class DomainWriter(BaseWriter):
+    """Writer for ATS domain elements."""
+    def __init__(self):
+        super(DomainWriter, self).__init__()
+
+    def write(self, xml_root):
+        # possible children parameters
+        children = {
+            'generate mesh': ['domain low coordinate', 'domain high coordinate', 'number of cells'],
+            'read mesh file': ['file', 'format'],
+            'surface': ['urface sideset name', 'export mesh to file', ], # TODO: more
+            'subgrid': ['subgrid region name', 'entity kind', 'parent domain', 'flyweight mesh'],
+            # TODO: column mesh
+        }
+        main_param_names = ['verify mesh', 'deformable mesh']
+        # Note about `'partitioner'`: it only makes sense on the "domain" mesh
+        ####
+        # Logic to render the mesh section
+        mesh_elem = self._new_list(xml_root, 'mesh')
+        domain_atts = shared.sim_atts.findAttributes('domain')
+        for domain_att in domain_atts:
+            # save out each domain
+            domain_elem = self._new_list(mesh_elem, domain_att.name())
+            type_item = domain_att.findString('mesh type')
+            mesh_type = type_item.value()
+            _ = self._new_param(domain_elem, 'mesh type', 'string', mesh_type)
+            #  Winging it here to generate the parameters list
+            gen_params_list_name = '{} parameters'.format(mesh_type)
+            gen_params_list = self._new_list(domain_elem, gen_params_list_name)
+            known_children = children.get(mesh_type, [])
+            self._render_items(gen_params_list, type_item, known_children)
+            # TODO: If a `domain` mesh, not a surface or otherwise, add the partitioner option:
+            #       there aren't any examples of this being used, so leaving out
+            # if domain mesh: # psuedo-code
+            #     self._render_items(gen_params_list, type_item, ['partitioner',])
+            # Top level mesh parameters
+            self._render_items(domain_elem, domain_att, main_param_names)
+        return

--- a/dev/cmb/simulation-workflows/ats/internal/writer/shared_data.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/shared_data.py
@@ -1,0 +1,45 @@
+"""Data shared among all writers"""
+
+class SharedData:
+    """Singleton class"""
+    _instance = None
+
+    def __init__(self):
+        """A singleton storing data to be shared across all writers.
+
+        Recommended usage:
+        from .shared_data import instance as shared
+        """
+        if self.__class__._instance is not None:
+            raise RuntimeError('Invalid to instantiate SharedData more than once')
+            self.__class__._instance = self
+
+        self._checked_attributes = set()
+        self._sim_atts = None
+        self._warning_messages = list()
+        self._xml_doc = None
+
+    def initialize(self, sim_atts, xml_doc):
+        """Configure data for next xml document."""
+        self._checked_attributes.clear()
+        self._sim_atts = sim_atts
+        del self._warning_messages[:]
+        self._xml_doc = xml_doc
+
+    @property
+    def checked_attributes(self):
+        return self._checked_attributes
+
+    @property
+    def sim_atts(self):
+        return self._sim_atts
+
+    @property
+    def warning_messages(self):
+        return self._warning_messages
+
+    @property
+    def xml_doc(self):
+        return self._xml_doc
+
+instance = SharedData()


### PR DESCRIPTION
There can be multiple meshes ("domain"s) per simulation as stated in the ATS docs:

> Multiple domains and therefore meshes can be used in a single simulation

These changes split out the domains and regions attributes into separate groups. Now the user can create N-domains.

![Screen Shot 2020-05-01 at 10 06 10 AM](https://user-images.githubusercontent.com/22067021/80811201-66d65f80-8b93-11ea-9e1c-658318694745.png)
