### PR TITLE
Use more brute force to set path to smtk python modules

### DIFF
--- a/dev/cmb/simulation-workflows/ats/ats.py
+++ b/dev/cmb/simulation-workflows/ats/ats.py
@@ -30,7 +30,7 @@ elif sys.platform == "darwin":
         if app_pos > 0:
             end_pos = app_pos + len(app_name)
             app_path = p[:end_pos]
-            site_path = os.path.join(app_path, '/', 'Python')
+            site_path = os.path.join(app_path, 'Contents', 'Python')
             break
 elif sys.platform == "linux":
     site_path = os.path.join(sys.prefix, "lib", "python3.7", "site-packages")

--- a/dev/cmb/simulation-workflows/ats/ats.py
+++ b/dev/cmb/simulation-workflows/ats/ats.py
@@ -23,9 +23,15 @@ site_path = None
 if sys.platform == "win32":
     site_path = os.path.join(sys.prefix, "bin", "Lib", "site-packages")
 elif sys.platform == "darwin":
-    site_path = os.path.join(
-        sys.prefix, os.pardir, os.pardir, os.pardir, os.pardir, "Python"
-    )
+    # Look for modelbuilder.app in sys.path
+    app_name = 'modelbuilder.app'
+    for p in sys.path:
+        app_pos = p.rfind(app_name)
+        if app_pos > 0:
+            end_pos = app_pos + len(app_name)
+            app_path = p[:end_pos]
+            site_path = os.path.join(app_path, '/', 'Python')
+            break
 elif sys.platform == "linux":
     site_path = os.path.join(sys.prefix, "lib", "python3.7", "site-packages")
 else:


### PR DESCRIPTION
Another change to the modelbuilder/macOS package has rendered the previous workaround for sys.path moot. This MR has a more naive (but still brute force) workaround.