### PR TITLE
Add ATS version choice to templates/writer

### DIFF
--- a/dev/cmb/simulation-workflows/ats/ats.sbt
+++ b/dev/cmb/simulation-workflows/ats/ats.sbt
@@ -2,6 +2,7 @@
 <SMTK_AttributeResource Version="3">
   <!-- ATS's top level -->
   <Includes>
+    <File>internal/templates/ats-info.sbt</File>
     <!-- Mesh and Regions -->
     <File>internal/templates/domain.sbt</File>
     <File>internal/templates/region.sbt</File>
@@ -35,8 +36,14 @@
 
     <View Type="Group" Title="Mesh" Style="Tiled">
       <Views>
+        <View Title="ATS Information"/>
         <View Title="Mesh Attributes"/>
       </Views>
+    </View>
+    <View Type="Instanced" Title="ATS Information">
+      <InstancedAttributes>
+        <Att Type="ATS Information" Name="ATS Information"/>
+      </InstancedAttributes>
     </View>
     <View Type="Instanced" Title="Domain">
       <InstancedAttributes>

--- a/dev/cmb/simulation-workflows/ats/internal/templates/ats-info.sbt
+++ b/dev/cmb/simulation-workflows/ats/internal/templates/ats-info.sbt
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SMTK_AttributeResource Version="3">
+  <Definitions>
+    <AttDef BaseType="" Type="ATS Information" Version="0">
+      <ItemDefinitions>
+        <String Name="ATS Version">
+          <DiscreteInfo DefaultIndex="0">
+            <Value>master-branch</Value>
+            <Value>0.88</Value>
+          </DiscreteInfo>
+        </String>
+      </ItemDefinitions>
+    </AttDef>
+  </Definitions>
+</SMTK_AttributeResource>

--- a/dev/cmb/simulation-workflows/ats/internal/writer/pk_writer.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/pk_writer.py
@@ -23,6 +23,10 @@ class PKWriter(BaseWriter):
 
     def __init__(self):
         super(PKWriter, self).__init__()
+        # TODO: this is such a hack of a solution.
+        self.use_units = True
+        if shared.ats_version != 'master-branch':
+            self.use_units = False
 
     def _generate_time_integrator_section(self, parent, att):
         """Generates the XML elements for the time integrator section.
@@ -417,10 +421,10 @@ class PKWriter(BaseWriter):
             "modify predictor with consistent faces",
             "modify predictor for flux BCs",
             "modify predictor via water content",
-            "max valid change in saturation in a time step [-]",
-            "max valid change in ice saturation in a time step [-]",
-            "limit correction to pressure change [Pa]",
-            "limit correction to pressure change when crossing atmospheric [Pa]",
+            "max valid change in saturation in a time step" + " [-]" if self.use_units else "",
+            "max valid change in ice saturation in a time step" + " [-]" if self.use_units else "",
+            "limit correction to pressure change" + " [Pa]" if self.use_units else "",
+            "limit correction to pressure change when crossing atmospheric" + " [Pa]" if self.use_units else "",
             "permeability rescaling",
         ]
         self._render_items(pk_elem, att, options)
@@ -432,12 +436,12 @@ class PKWriter(BaseWriter):
         wre_params = self._new_list(wre_elem, "WRM parameters")
         wrm_options = {
             "van Genuchten": [
-                "van Genuchten alpha [Pa^-1]",
-                "residual saturation [-]",
-                "Mualem exponent l [-]",
-                "van Genuchten m [-]",
-                "smoothing interval width [saturation]",
-                "saturation smoothing interval [Pa]",
+                "van Genuchten alpha" + " [Pa^-1]" if self.use_units else "",
+                "residual saturation" + " [-]" if self.use_units else "",
+                "Mualem exponent l" + " [-]" if self.use_units else "",
+                "van Genuchten m" + " [-]" if self.use_units else "",
+                "smoothing interval width" + " [saturation]" if self.use_units else "",
+                "saturation smoothing interval" + " [Pa]" if self.use_units else "",
             ],
         }
         evaluator = att.findGroup("WRM evaluators")
@@ -461,8 +465,8 @@ class PKWriter(BaseWriter):
     def _render_pk_overland_pressure(self, pk_elem, att):
         self._render_pk_physical_bdf(pk_elem, att)
         options = [
-            "imit correction to pressure change [Pa]",
-            "limit correction to pressure change when crossing atmospheric [Pa]",
+            "imit correction to pressure change" + " [Pa]" if self.use_units else "",
+            "limit correction to pressure change when crossing atmospheric" + " [Pa]" if self.use_units else "",
             "allow no negative ponded depths",
             "min ponded depth for velocity calculation",
             "min ponded depth for tidal bc",

--- a/dev/cmb/simulation-workflows/ats/internal/writer/shared_data.py
+++ b/dev/cmb/simulation-workflows/ats/internal/writer/shared_data.py
@@ -44,5 +44,10 @@ class SharedData:
     def xml_doc(self):
         return self._xml_doc
 
+    @property
+    def ats_version(self):
+        ats_info = self.sim_atts.findAttribute("ATS Information")
+        return ats_info.find("ATS Version").value()
+
 
 instance = SharedData()


### PR DESCRIPTION
@johnkit, this is a crude implementation of adding a field to specify which version of ATS to have the writers fulfill... this is not sustainable at all, but it should do the trick for the demos.

I may have missed a few other differences between master/1.0 and 0.88, but this would be the implementation